### PR TITLE
refactored character image swap & refined dialogue

### DIFF
--- a/CatAndNeighborsVN/Assets/Scenes/Day1/Day_1.unity
+++ b/CatAndNeighborsVN/Assets/Scenes/Day1/Day_1.unity
@@ -2754,10 +2754,6 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 77d8f11e4af00594c8aaf1784c1dd7a8, type: 3}
   - {fileID: 21300000, guid: 7662955175de7594d82ecba6748cb9fb, type: 3}
   - {fileID: 21300000, guid: 7b7779375d8eefa4681ba7916fcc8be9, type: 3}
-  - {fileID: 21300000, guid: ae6f5e52731c6c24a92da1549309d748, type: 3}
-  - {fileID: 21300000, guid: 76101190d1740a642b512df3e1d9af51, type: 3}
-  - {fileID: 21300000, guid: c4aedfb0c2c1d8b49a2f8c33bc4026a2, type: 3}
-  - {fileID: 21300000, guid: 0729a5984c67fb642b655dcd55b70b0c, type: 3}
   loadAudio: []
   spriteGroup: {fileID: 0}
   bgImage: {fileID: 1827498648}

--- a/CatAndNeighborsVN/Assets/Scenes/Day1/Yarn/Day1_Script.yarn
+++ b/CatAndNeighborsVN/Assets/Scenes/Day1/Yarn/Day1_Script.yarn
@@ -62,7 +62,7 @@ group: mucciBag
 //1.4
 <<if getVampireNurseNotSelected()>>
     <<Scene bg_office>> // Replace with different background
-    <<Character dorian true>>
+    <<Character DORIAN true>>
     Dorian: Wow, Rowan, I didn’t know you had such luxurious taste.
     Rowan: Oh, no this isn’t mine, I found it this morning and thought it might belong to you?
     Dorian: I’m flattered, but no, this isn't mine. Although, it looks like something Marie-Elle might own. 
@@ -83,7 +83,7 @@ group: mucciBag
 //1.5
 <<if getPitifulRobotNotSelected()>>
     <<Scene bg_office>> // Replace with different background
-    <<Character fern true>>
+    <<Character feRn true>>
     Fern: This is a certified Mucci bag. My human could afford one of these, but they don’t get outside much to make use of it. 
     Rowan: Maybe it could be theirs? 
     Fern: No, there are no such items in the inventory.  I have no need for such grocery bags either. 

--- a/CatAndNeighborsVN/Assets/Scenes/Day1/Yarn/Day1_Script.yarn
+++ b/CatAndNeighborsVN/Assets/Scenes/Day1/Yarn/Day1_Script.yarn
@@ -50,7 +50,6 @@ An expensive lipstick brand that looks like it’s almost used up.
 title: Character_Select
 ---
 <<Scene bg_interact>>
-<<ResetPos>>
 <<hide_item>>
 Rowan: Who does this belong to?
 <<neighbor_selection>>
@@ -61,15 +60,16 @@ color: purple
 group: mucciBag
 ---
 //1.4
-<<Scene bg_office>> // Replace with different background
-<<Characters no no middle no>>
 <<if getVampireNurseNotSelected()>>
+    <<Scene bg_office>> // Replace with different background
+    <<Character dorian true>>
     Dorian: Wow, Rowan, I didn’t know you had such luxurious taste.
     Rowan: Oh, no this isn’t mine, I found it this morning and thought it might belong to you?
     Dorian: I’m flattered, but no, this isn't mine. Although, it looks like something Marie-Elle might own. 
     Dorian: But I’ll gladly take it off your hands.
     Rowan: Nice try, but no. 
     <<setVampireNurseNotSelected false>>
+    <<Character dorian false>>
     <<jump Character_Select>>
 <<else>>
     <<jump Already_Selected>>
@@ -81,17 +81,25 @@ color: purple
 group: mucciBag
 ---
 //1.5
-<<Scene bg_office>> // Replace with different background
-<<Characters no no no middle>>
 <<if getPitifulRobotNotSelected()>>
+    <<Scene bg_office>> // Replace with different background
+    <<Character fern true>>
     Fern: This is a certified Mucci bag. My human could afford one of these, but they don’t get outside much to make use of it. 
     Rowan: Maybe it could be theirs? 
-    Fern: No, there are no such items in the inventory.  I have no need for such grocery bags either. Fern: It’s expensive despite how little it carries. Very odd, just like artists. 
+    Fern: No, there are no such items in the inventory.  I have no need for such grocery bags either. 
+    Fern: It’s expensive despite how little it carries. Very odd, just like artists. 
     <<setPitifulRobotNotSelected false>>
+    <<Character fern false>>
     <<jump Character_Select>>
 <<else>>
     <<jump Already_Selected>>
 <<endif>>
+===
+
+title: Already_Selected
+---
+Rowan: I already checked with them.
+<<neighbor_selection>>
 ===
 
 title: levelOneMarie
@@ -100,11 +108,12 @@ group: mucciBag
 ---
 //1.6
 <<Scene bg_office>> // Replace with different background
-<<Characters no middle no no>>
+<<Character fashiondesigner true>>
 Rowan: Hello? Is anyone in right now?
 (DOOR SLIGHTLY OPENS W/ ONLY HALF OF FASHION DESIGNER’S FACE PEEKING OUT)
 Marie-Elle: I currently don’t accept visitors! Or ever really!
 Rowan: Wait! But I -
+<<Character fashiondesigner false>>
 (SLAMS DOOR)
 Rowan: …
 Rowan: That was a bit rude. They didn’t even let me finish my sentence.
@@ -115,27 +124,28 @@ Rowan: She probably didn’t hear me knocking.
 Rowan: I’m sure she’ll eventually answer?
 ->Hope
 Rowan: Now I’m a bit worried.
+<<Character fashiondesigner true>>
 (Marie-Elle OPENS DOOR)
 Marie-Elle: Why is it that you keep insisting to pound on my door? I am baffled at your inability to take a hint when I didn’t answer the door for 5 minutes.
 Marie-Elle: I’m currently in the midst of something very important and each second here takes away another second I can be using productively elsewhere.
 Marie-Elle: Come on! Tell me quickly so we can get this over with. 
-Rowan: Hi, I’m Rowan and I recently moved in next door. I found a bag and I’m looking for the bag’s owner so that I can return it ASAP.
+Rowan: Hi, I’m Rowan and I recently moved in next door in Apartment H8. I found a bag and I’m looking for the bag’s owner so that I can return it ASAP.
 Marie-Elle: A bag? Would it happen to a Mucci purse?
-Rowan: Ah yes! It is a Mucci purse. A __pink__ Mucci purse?
+Rowan: Ah yes! It is a Mucci purse. A pink Mucci purse?
 Marie-Elle: I believe I may be the owner of the purse you claim to have found. Your visit is now very much welcomed.
 Marie-Elle: Tell me again how and where you came upon my missing Mucci purse?
 Rowan: I came back from work today and saw a Mucci bag on the coffee table in my living room.
-Rowan: My cat Selina was sitting next to it and staring at me so the only explanation how the purse got into my apartment is that CAT stole it.
-Marie-Elle: … Your cat stole the purse and you found it lying in your living room after work? Is this some new variation of “my dog ate my homework”?
+Rowan: My cat, Selina, was sitting next to it and staring at me so the only explanation how the purse got into my apartment is that Selina stole it.
+Marie-Elle: … Your cat stole the purse and you found it lying in your living room after work? Is this some new variation of “my dog ate my homework?”
 ->Prank
     Rowan: You’ve been pranked!
-    Marie-Elle: Don’t tell me you’re secretly filming me for a hidden prank TikTok or something.
+    Marie-Elle: Don’t tell me you’re secretly filming me for a hidden prank PikPok or something.
     Marie-Elle: I don’t think this kind of prank will blow up online enough to warrant embarrassing yourself with such a half-brained excuse.
 ->Talent
     Rowan: My cat has a hidden talent in thievery it seems.
     Marie-Elle: I’m not sure that’s something to be proud of as the owner of the cat.
     Marie-Elle: It does not bode well for you in the future if you get implicated in a crime.
-Marie-Elle: Do you seriously think I’ll believe that your cat somehow stole a designer bag without a scratch or bite marks to indicate how it apparently carried the purse to your apartment?
+Marie-Elle: Do you seriously think I’ll believe that your cat somehow stole a designer bag without a scratch or without bite marks to indicate how it apparently carried the purse to your apartment?
 Rowan: When you say it that way, it does seem far-fetched … but I swear it’s the truth!
 Rowan: Look! I even brought my cat to apologize!
 (PICKS UP SELINA AND SHOVES SELINA INTO FASHION DESIGNER’S FACE)
@@ -151,7 +161,7 @@ Rowan: I’ll leave Selina in my apartment for now!
 Selina: (OUTRAGED) MEOW?!
 (ROWAN RUNS OVER TO APARTMENT TO PUT SOME DISTANCE)
 Rowan: I’m sorry about that! If I knew you were allergic, I wouldn’t have brought Selina with me to return the purse.
-Marie-Elle: I was starting to wonder why my nose was starting to get stuffy out of the blue. AH CHOO
+Marie-Elle: I was starting to wonder why my nose was starting to get stuffy out of the blue. AH CHOO!
 Rowan: How bad is your cat allergy? If you need to get any medicine, I’ll compensate you!
 Marie-Elle: (SNIFF) Nothing too serious thankfully, but enough for me to have a stuffy nose and rashes for a few days. Can’t say I won’t be irritated the whole time though.
 Marie-Elle: I also have something at home to take care of my allergies so no need for compensation. 
@@ -159,7 +169,7 @@ Marie-Elle: But I believe you have a purse to return to me.
 Rowan: Yes! Here you go. I grabbed the purse from the apartment on my way back.
 (BAG IS GIVEN BACK)
 Rowan: I hope this is the right one you’re looking for.
-Marie-Elle: – describe bag like if she’s inspecting its the right one –. 
+Marie-Elle: (MUTTERS) Muted fuchsia with an eggplant frame. Spotted like a cheetah. Clasps open like those Japanese kindergarten backpacks.
 Marie-Elle: Yes, this is the one. 
 Rowan: I’m sorry again that my cat stole your purse.
 Marie-Elle: You still are saying that the cat stole it? I admire your stubbornness.
@@ -179,7 +189,7 @@ Marie-Elle: This is a small request in comparison no matter how I feel about the
     Marie-Elle: Even I am a bit skeptical and I believe all fashion should be appreciated in its own way.
 ->Haute couture.
     Rowan: I love the design of the purse! Very haute couture.
-    Marie-Elle: Ah… You do?
+    Marie-Elle: (DOUBTFUL) Ah… You do?
     Marie-Elle: Well, taste is subjective and varies by person.
 Marie-Elle: Every style has its own admirers since if somebody can think of a creation surely there will be someone in this world who can admire the piece.
 Rowan: Well, I’m glad that I was able to return the purse to you. 
@@ -188,15 +198,16 @@ Marie-Elle: Is there anything else you need now that you’re lingering at my do
 Rowan: Ah… I introduced myself earlier, but still don’t know your name yet so I was hoping you’ll introduce yourself?
 Marie-Elle: Why do you sound so uncertain that you want to know who I am? Either you do or you don’t. Ask again, but this time be more confident.
 Rowan: May I please know your name? I would like to get to know my neighbors that I’ll be seeing in the future.
-Marie-Elle: I am Marie-Elle, tenant of Apartment H4, owner of the Mucci purse your cat “stole.” 
+Marie-Elle: I am Marie-Elle, tenant of Apartment H7, owner of the Mucci purse your cat, Selina, “stole.” 
 Rowan: You’re never going to let me live that down are you?
 Marie-Elle: It is a memorable first impression I must say.
 Rowan: And if it’s not too much to ask, what do you do for a living to have high profile clients? 
-Rowan: I’m … funemployed if that makes you more comfortable.
+Rowan: I’m … FUnemployed if that makes you more comfortable.
 Marie-Elle:  Let’s just say for now that I am a … creative. 
 Marie-Elle: Well, I must say goodbye now. Even if I do appreciate that you returned the Mucci purse to me, time waits for no one. I still have a lot of work to do to stay at the caliber that I am known for.
 Rowan: I’m sorry again! Bye and thanks for answering the door the second time.
 Marie-Elle: No need to apologize more about the same thing multiple times. When I say it’s fine, I really mean it.
 Marie-Elle: I hope our next meeting is on better terms. Goodbye, Rowan.
+<<Character fashiondesigner false>>
 <<change_scene Day_2>>
 ===

--- a/CatAndNeighborsVN/Assets/Scenes/Scripts/YarnCommands.cs
+++ b/CatAndNeighborsVN/Assets/Scenes/Scripts/YarnCommands.cs
@@ -32,15 +32,9 @@ public class YarnCommands : MonoBehaviour
         dialogueRunner.AddCommandHandler("hide_item", HideInteract);
         dialogueRunner.AddCommandHandler("neighbor_selection", Selection);
 		dialogueRunner.AddCommandHandler<string>("Scene", DoSceneChange);
-		dialogueRunner.AddCommandHandler<string, string, string, string>("Characters", LoadCharacters);
-		dialogueRunner.AddCommandHandler<string, string, string, string>("ResetPos", ResetPosition);
+		dialogueRunner.AddCommandHandler<string, bool>("Character", LoadCharacters);
 		dialogueRunner.AddCommandHandler("show_living_room", ShowLivingRoom);
 		dialogueRunner.AddCommandHandler("hide_living_room", HideLivingRoom);
-		
-		catImage.GetComponent<Image>().sprite = FetchAsset<Sprite>("cat");
-		fashionDesignerImage.GetComponent<Image>().sprite = FetchAsset<Sprite>("fashionDesigner");
-		vampireNurseImage.GetComponent<Image>().sprite = FetchAsset<Sprite>("vampireNurse");
-		pitifulRobotImage.GetComponent<Image>().sprite = FetchAsset<Sprite>("pitifulRobot");
 
 		itemInteractionCanva.SetActive(false);
         neighborSelectionCanva.SetActive(false);
@@ -55,92 +49,48 @@ public class YarnCommands : MonoBehaviour
 		bgImage.sprite = FetchAsset<Sprite>( spriteName );
 	}
 
-	public void LoadCharacters(string cat = "no", string fashionDesigner = "no", string vampireNurse = "no", string pitifulRobot = "no") {
-		if (cat != "no") {
-			catImage.SetActive(true);
-			if (cat == "left") {
-				catImage.transform.position = catImage.transform.position + left;
-				Debug.Log("POSITION " + catImage.transform.position);
+	// To turn on character image: <<Character cat true>>
+	// To turn off character image: <<Character FashionDesigner false>>
+	// Character's title or name works so you can write <<Character Dorian/vampirenurse true/false>>
+	public void LoadCharacters(string character, bool active) {
+		if (character.ToLower() == "cat" || 
+			character.ToLower() == "selina") {
+			if (active) {
+				catImage.SetActive(true);
+			} else {
+				catImage.SetActive(false);
 			}
-			if (cat == "right") {
-				catImage.transform.position = catImage.transform.position + right;
+		}
+		
+		if (character.ToLower() == "fashiondesigner" || 
+			character.ToLower() == "marieelle" || 
+			character.ToLower() == "marie-elle") {
+			if (active) {
+				fashionDesignerImage.SetActive(true);
+			} else {
+				fashionDesignerImage.SetActive(false);
 			}
 		}
 
-		if (fashionDesigner != "no") {
-			fashionDesignerImage.SetActive(true);
-			if (fashionDesigner == "left") {
-				fashionDesignerImage.transform.position = fashionDesignerImage.transform.position + left;
-			}
-			if (fashionDesigner == "right") {
-				fashionDesignerImage.transform.position = fashionDesignerImage.transform.position + right;
-			}
-		}
-
-		if (vampireNurse != "no") {
-			vampireNurseImage.SetActive(true);
-			if (vampireNurse == "left") {
-				vampireNurseImage.transform.position = vampireNurseImage.transform.position + left;
-			}
-			if (vampireNurse == "right") {
-				vampireNurseImage.transform.position = vampireNurseImage.transform.position + right;
+		if (character.ToLower() == "vampirenurse" || 
+			character.ToLower() == "dorian" ||
+			character.ToLower() == "dorianvayne") {
+			if (active) {
+				vampireNurseImage.SetActive(true);
+			} else {
+				vampireNurseImage.SetActive(false);
 			}
 		}
 
-		if (pitifulRobot != "no") {
-			pitifulRobotImage.SetActive(true);
-			if (pitifulRobot == "left") {
-				pitifulRobotImage.transform.position = pitifulRobotImage.transform.position + left;
-			}
-			if (pitifulRobot == "right") {
-				pitifulRobotImage.transform.position = pitifulRobotImage.transform.position + right;
+		if (character.ToLower() == "pitifulrobot" || 
+			character.ToLower() == "fern") {
+			if (active) {
+				pitifulRobotImage.SetActive(true);
+			} else {
+				pitifulRobotImage.SetActive(false);
 			}
 		}
 	}
-	
-	public void ResetPosition(string cat = "no", string fashionDesigner = "no", string vampireNurse = "no", string pitifulRobot = "no") {
-		if (cat == "no") {
-			catImage.SetActive(false);
-			if (cat == "left") {
-				catImage.transform.position = catImage.transform.position - left;
-			}
-			if (cat == "right") {
-				catImage.transform.position = catImage.transform.position - right;
-			}
-		} 
-
-		if (fashionDesigner == "no") {
-			fashionDesignerImage.SetActive(false);
-			if (fashionDesigner == "left") {
-				fashionDesignerImage.transform.position = fashionDesignerImage.transform.position - left;
-			}
-			if (fashionDesigner == "right") {
-				fashionDesignerImage.transform.position = fashionDesignerImage.transform.position - right;
-			}
-		}
-
-		if (vampireNurse == "no") {
-			vampireNurseImage.SetActive(false);
-			if (vampireNurse == "left") {
-				vampireNurseImage.transform.position = vampireNurseImage.transform.position - left;
-			}
-			if (vampireNurse == "right") {
-				vampireNurseImage.transform.position = vampireNurseImage.transform.position - right;
-			}
-			
-		}
-
-		if (pitifulRobot == "no") {
-			pitifulRobotImage.SetActive(false);
-			if (pitifulRobot == "left") {
-				pitifulRobotImage.transform.position = pitifulRobotImage.transform.position - left;
-			}
-			if (pitifulRobot == "right") {
-				pitifulRobotImage.transform.position = pitifulRobotImage.transform.position - right;
-			}
-		}
-	}
-	
 
     private void ChangeScene(string sceneName) {
         Debug.Log("loading scene");


### PR DESCRIPTION
Character image swap now only requires one character with a true/false bool to turn on/off the character image. Character's names or titles can be used to turn on/off their images. The command is also case insensitive.
Examples:
Character cat true
Character cAt false
Character Dorian true
Character vampireNURSE false
Still won't let me put <<>> in the commands example.